### PR TITLE
Add correct amount to amount fields for Get started samples

### DIFF
--- a/get-started/step-4-1/request.json
+++ b/get-started/step-4-1/request.json
@@ -3,7 +3,7 @@
     "type": "token",
     "token": "tok_XXX"
   },
-  "amount": 24.99,
+  "amount": 2499,
   "currency": "USD",
   "processing_channel_id": "pc_XXX"
 }

--- a/get-started/troubleshoot/201-approved-response/201-approved-response.json
+++ b/get-started/troubleshoot/201-approved-response/201-approved-response.json
@@ -1,7 +1,7 @@
 {
   "id": "pay_qzpz6fv4dv2etnarerhvqxsvlm",
   "action_id": "act_agaoqbtsccie5j2zd6jwdodpg4",
-  "amount": 24.99,
+  "amount": 2499,
   "currency": "USD",
   "approved": true,
   "status": "Authorized",
@@ -9,11 +9,11 @@
   "response_code": "10000",
   "response_summary": "Approved",
   "balances": {
-    "total_authorized": 24.99,
+    "total_authorized": 2499,
     "total_voided": 0,
-    "available_to_void": 24.99,
+    "available_to_void": 2499,
     "total_captured": 0,
-    "available_to_capture": 24.99,
+    "available_to_capture": 2499,
     "total_refunded": 0,
     "available_to_refund": 0
   },


### PR DESCRIPTION
# [WRITING-1542](https://checkout.atlassian.net/browse/WRITING-1542)

Updates the request and response `amount` fields, following [this feedback in ask-docs](https://checkout.slack.com/archives/C3RAJ3T42/p1683021783332839):

> Hello Team can you please check the amounts in the docs? In the [Get started](https://www.checkout.com/docs/get-started#Send_payment_request) guide we have 24.99 instead of 2499. Can you please check the other API requests as well?